### PR TITLE
Fix: apcupsd behavior is a bit too much paranoid with shutdown

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,13 @@ ups__configure: False
 # defaults file for empty
 ups__default_packages:
   - apcupsd
+
+ups__scriptlist:
+  - changeme
+  - apccontrol
+  - failing # Battery fail
+  - doshutdown # When shutdown is initiated
+
+ups__conf:
+  battery_level: 8
+  time_left: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,15 @@
     state: present
   when: ups__install
 
-- name: Setup apcupsd.conf
+- name: Setup config file apcupsd.conf
   template:
     src: apcupsd.conf
     dest: /etc/apcupsd/apcupsd.conf
   when:
     - ups__configure
-  # notify: Reload exim4
+
+- include_tasks: setup_scripts.yml
+  loop: "{{ ups__scriptlist }}"
+  when:
+    - ups__configure
 

--- a/tasks/setup_scripts.yml
+++ b/tasks/setup_scripts.yml
@@ -1,0 +1,5 @@
+---
+- name: Setup {{ item }} script
+  template:
+    src: "{{ item }}"
+    dest: "/etc/apcupsd/{{ item }}"

--- a/templates/apccontrol
+++ b/templates/apccontrol
@@ -1,0 +1,136 @@
+#!/bin/sh
+#
+# Copyright (C) 1999-2002 Riccardo Facchetti <riccardo@master.oasi.gpa.it>
+#
+# platforms/apccontrol.  Generated from apccontrol.in by configure.
+#
+#  Note, this is a generic file that can be used by most
+#   systems. If a particular system needs to have something
+#   special, start with this file, and put a copy in the
+#   platform subdirectory.
+#
+
+#
+# These variables are needed for set up the autoconf other variables.
+#
+prefix=/usr
+exec_prefix=${prefix}
+
+APCPID=/var/run/apcupsd.pid
+APCUPSD=/sbin/apcupsd
+SHUTDOWN=/sbin/shutdown
+SCRIPTSHELL=/bin/sh
+SCRIPTDIR=/etc/apcupsd
+WALL=wall
+
+export SYSADMIN=root
+export APCUPSD_MAIL="mail"
+if [ -f $SCRIPTDIR/config ]; then . $SCRIPTDIR/config ; fi
+
+#
+# Concatenate all output from this script to the events file
+#  Note, the following kills the script in a power fail situation
+#   where the disks are mounted read-only.
+# exec >>/var/log/apcupsd.events 2>&1
+
+#
+# This piece is to substitute the default behaviour with your own script,
+# perl, or C program.
+# You can customize every single command creating an executable file (may be a
+# script or a compiled program) and calling it the same as the $1 parameter
+# passed by apcupsd to this script.
+#
+# After executing your script, apccontrol continues with the default action.
+# If you do not want apccontrol to continue, exit your script with exit 
+# code 99. E.g. "exit 99".
+#
+# WARNING: the apccontrol file will be overwritten every time you update your
+# apcupsd, doing `make install'. Your own customized scripts will _not_ be
+# overwritten. If you wish to make changes to this file (discouraged), you
+# should change apccontrol.sh.in and then rerun the configure process.
+#
+if [ -f ${SCRIPTDIR}/${1} -a -x ${SCRIPTDIR}/${1} ]
+then
+    ${SCRIPTDIR}/${1} ${2} ${3} ${4}
+    # exit code 99 means he does not want us to do default action
+    if [ $? = 99 ] ; then
+	exit 0
+    fi
+fi
+
+case "$1" in
+    killpower)
+	echo "Apccontrol doing: ${APCUPSD} --killpower on UPS ${2}" | (${WALL} 2>/dev/null || cat)
+	sleep 10
+	${APCUPSD} --killpower
+	echo "Apccontrol has done: ${APCUPSD} --killpower on UPS ${2}" | (${WALL} 2>/dev/null || cat)
+    ;;
+    commfailure)
+	echo "Warning communications lost with UPS ${2}" | ${WALL}
+    ;;
+    commok)
+	echo "Communications restored with UPS ${2}" | ${WALL}
+    ;;
+#
+# powerout, onbattery, offbattery, mainsback events occur
+#   in that order.
+#
+    powerout)
+    ;;
+    onbattery)
+	echo "Power failure on UPS ${2}. Running on batteries." | ${WALL}
+    ;;
+    offbattery)
+	echo "Power has returned on UPS ${2}..." | ${WALL}
+    ;;
+    mainsback)
+	if [ -f /etc/apcupsd/powerfail ] ; then
+	   printf "Continuing with shutdown."  | ${WALL}
+	fi
+    ;;
+    failing)
+	echo "Battery power exhausted on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    timeout)
+	echo "Battery time limit exceeded on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    loadlimit)
+	echo "Remaining battery charge below limit on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    runlimit)
+	echo "Remaining battery runtime below limit on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    doreboot)
+	echo "UPS ${2} initiating Reboot Sequence" | ${WALL}
+	${SHUTDOWN} -r now "apcupsd UPS ${2} initiated reboot"
+    ;;
+    doshutdown)
+	echo "UPS ${2} initiated Shutdown Sequence" | ${WALL}
+	${SHUTDOWN} -h now "apcupsd UPS ${2} initiated shutdown"
+    ;;
+    annoyme)
+	echo "Power problems with UPS ${2}. Please logoff." | ${WALL}
+    ;;
+    emergency)
+	echo "Emergency Shutdown. Possible battery failure on UPS ${2}." | ${WALL}
+    ;;
+    changeme)
+	echo "Emergency! Batteries have failed on UPS ${2}. Change them NOW" | ${WALL}
+    ;;
+    remotedown)
+	echo "Remote Shutdown. Beginning Shutdown Sequence." | ${WALL}
+    ;;
+    startselftest)
+    ;;
+    endselftest)
+    ;;
+    battdetach)
+    ;;
+    battattach)
+    ;;
+    *)	echo "Usage: ${0##*/} command"
+	echo "	     warning: this script is intended to be launched by"
+	echo "	     apcupsd and should never be launched by users."
+	exit 1
+    ;;
+esac

--- a/templates/apcupsd.conf
+++ b/templates/apcupsd.conf
@@ -15,7 +15,7 @@
 #   Use this to give your UPS a name in log files and such. This
 #   is particulary useful if you have multiple UPSes. This does not
 #   set the EEPROM. It should be 8 characters or less.
-#UPSNAME
+UPSNAME procplant
 
 # UPSCABLE <cable>
 #   Defines the type of cable connecting the UPS to your computer.
@@ -137,7 +137,7 @@ NOLOGINDIR /etc
 #   ONBATTERYDELAY time.  If you don't want to be annoyed by short
 #   powerfailures, make sure that apccontrol powerout does nothing
 #   i.e. comment out the wall.
-ONBATTERYDELAY 6
+ONBATTERYDELAY 30
 
 # 
 # Note: BATTERYLEVEL, MINUTES, and TIMEOUT work in conjunction, so
@@ -147,12 +147,12 @@ ONBATTERYDELAY 6
 # If during a power failure, the remaining battery percentage
 # (as reported by the UPS) is below or equal to BATTERYLEVEL, 
 # apcupsd will initiate a system shutdown.
-BATTERYLEVEL 5
+BATTERYLEVEL {{ ups__conf.battery_level }}
 
 # If during a power failure, the remaining runtime in minutes 
 # (as calculated internally by the UPS) is below or equal to MINUTES,
 # apcupsd, will initiate a system shutdown.
-MINUTES 3
+MINUTES {{ ups__conf.time_left }}
 
 # If during a power failure, the UPS has run on batteries for TIMEOUT
 # many seconds or longer, apcupsd will initiate a system shutdown.
@@ -226,7 +226,7 @@ EVENTSFILE /var/log/apcupsd.events
 #  be removed from the beginning of the file (first in first out).  The
 #  parameter EVENTSFILEMAX can be set to a different kilobyte value, or set
 #  to zero to allow the EVENTSFILE to grow without limit.
-EVENTSFILEMAX 10
+EVENTSFILEMAX 100
 
 #
 # ========== Configuration statements used if sharing =============

--- a/templates/changeme
+++ b/templates/changeme
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# detects that the battery should be replaced.
+# We send an email message to root to notify him.
+#
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME UPS $1 battery needs changing NOW."
+#
+# Small wait and check status
+sleep 1m
+STATUS=$(/sbin/apcaccess status|grep -e '^STATUS'|sed -e 's/.*: //;s/ *$//')
+if [ "$STATUS" != "ONLINE" ]
+then
+  (
+   echo "$MSG"
+   echo " "
+   echo "Status: >$STATUS<"
+   echo " "
+   /sbin/apcaccess status
+  ) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+  exit 0
+fi
+exit 99

--- a/templates/doshutdown
+++ b/templates/doshutdown
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# want to start a shutdown
+#
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME UPS $1 shutdown will be initiated."
+#
+TIME_REMAINING=$(/sbin/apcaccess status|grep TIMELEFT|sed 's/.* : //;s/ .*//;s/\..*//')
+CHARGE_REMAINING=$(/sbin/apcaccess status|grep BCHARGE|sed 's/.* : //;s/ .*//;s/\..*//')
+# STATUS=$(/sbin/apcaccess status|grep -e '^STATUS'|sed -e 's/.*: //;s/ *$//')
+if [ "${TIME_REMAINING}" -gt "5" ]
+then
+    MSG="$HOSTNAME UPS $1 battery reported wrongly failing"
+  (
+   echo "$MSG"
+   echo " "
+   echo "Time remaining: >$TIME_REMAINING<"
+   echo " "
+   /sbin/apcaccess status
+  ) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+  exit 99
+fi
+
+if [ "${CHARGE_REMAINING}" -gt "8" ]
+then
+    MSG="$HOSTNAME UPS $1 battery reported wrongly failing"
+  (
+   echo "$MSG"
+   echo " "
+   echo "Charge remaining: >$CHARGE_REMAINING<"
+   echo " "
+   /sbin/apcaccess status
+  ) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+  exit 99
+fi
+(
+ echo "$MSG"
+ echo " "
+ echo "Full status:"
+ echo " "
+ /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0

--- a/templates/failing
+++ b/templates/failing
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# detects that the battery is failing
+#
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME UPS $1 battery power exhausted."
+#
+TIME_REMAINING=$(/sbin/apcaccess status|grep TIMELEFT|sed 's/.* : //;s/ .*//;s/\..*//')
+CHARGE_REMAINING=$(/sbin/apcaccess status|grep BCHARGE|sed 's/.* : //;s/ .*//;s/\..*//')
+# STATUS=$(/sbin/apcaccess status|grep -e '^STATUS'|sed -e 's/.*: //;s/ *$//')
+if [ "${TIME_REMAINING}" -gt "{{ ups__conf.time_left }}" ]
+then
+    MSG="$HOSTNAME UPS $1 battery reported wrongly failing"
+  (
+   echo "$MSG"
+   echo " "
+   echo "Time remaining: >$TIME_REMAINING<"
+   echo " "
+   /sbin/apcaccess status
+  ) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+  exit 99
+fi
+
+if [ "${CHARGE_REMAINING}" -gt "{{ ups__conf.battery_level }}" ]
+then
+    MSG="$HOSTNAME UPS $1 battery reported wrongly failing"
+  (
+   echo "$MSG"
+   echo " "
+   echo "Charge remaining: >$CHARGE_REMAINING<"
+   echo " "
+   /sbin/apcaccess status
+  ) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+  exit 99
+fi
+MSG="$HOSTNAME UPS $1 battery seems failing"
+(
+ echo "$MSG"
+ echo " "
+ echo "Full status:"
+ echo " "
+ /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0


### PR DESCRIPTION
- Change conf values
- Add scripts to really check batt status (charge and delay)
- Avoid running shutdown when it's just a flicker